### PR TITLE
Add simple stock analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # test1.0
-seeing how all this works 
+
+This repository contains sample code for experimenting with Codex.
+
+## Stock Analysis Tool
+
+The `stock_analysis` package provides a simple script to compute moving
+averages from a CSV file of historical prices. It relies only on the
+Python standard library.
+
+### Usage
+
+Prepare a CSV file with at least a `close` column, then run:
+
+```bash
+python -m stock_analysis.analysis path/to/data.csv --window 10
+```
+
+This will print the moving average for each day after the first
+`window` observations.

--- a/stock_analysis/analysis.py
+++ b/stock_analysis/analysis.py
@@ -1,0 +1,59 @@
+"""Simple stock analysis tools using only the Python standard library."""
+
+import csv
+from pathlib import Path
+from typing import List
+
+
+def read_prices(csv_path: Path) -> List[float]:
+    """Read closing prices from a CSV file. Assumes a header with 'close'."""
+    prices = []
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                price = float(row["close"])
+            except (KeyError, ValueError):
+                continue
+            prices.append(price)
+    return prices
+
+
+def moving_average(prices: List[float], window: int) -> List[float]:
+    """Calculate a simple moving average for a given window size."""
+    if window <= 0:
+        raise ValueError("window must be > 0")
+    if len(prices) < window:
+        return []
+    avgs = []
+    for i in range(window - 1, len(prices)):
+        window_prices = prices[i - window + 1 : i + 1]
+        avgs.append(sum(window_prices) / window)
+    return avgs
+
+
+def main(csv_file: str, window: int = 5) -> None:
+    path = Path(csv_file)
+    prices = read_prices(path)
+    if not prices:
+        print("No valid closing prices found.")
+        return
+    ma = moving_average(prices, window)
+    print(f"Calculated {len(ma)} moving-average values with window={window}.")
+    for i, value in enumerate(ma, start=window):
+        print(f"Day {i}: {value:.2f}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Simple stock analysis")
+    parser.add_argument("csv_file", help="CSV file with a 'close' column")
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=5,
+        help="Moving average window size (default: 5)",
+    )
+    args = parser.parse_args()
+    main(args.csv_file, args.window)


### PR DESCRIPTION
## Summary
- add stock_analysis module with a simple script for moving averages
- update README with usage instructions

## Testing
- `python -m stock_analysis.analysis` (fails: required CSV argument)


------
https://chatgpt.com/codex/tasks/task_e_6844d5c83094833388a692256e4dbb58