### PR TITLE
Add Flask DCF web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ python -m stock_analysis.analysis path/to/data.csv --window 10
 
 This will print the moving average for each day after the first
 `window` observations.
+
+## Web App
+
+A simple Flask web application is provided for calculating discounted cash flow (DCF) values.
+Install Flask and run the server:
+
+```bash
+pip install Flask
+python webapp.py
+```
+
+Then open `http://127.0.0.1:5000/` in your browser to access the form. Enter the cash flow
+parameters, ticker symbol (optional to fetch current price) and the number of shares to
+see the estimated intrinsic value.

--- a/stock_analysis/dcf.py
+++ b/stock_analysis/dcf.py
@@ -1,0 +1,55 @@
+"""Discounted Cash Flow utilities."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Optional
+
+
+def compute_intrinsic_value(
+    fcf: float,
+    growth_rate: float,
+    discount_rate: float,
+    years: int,
+    terminal_growth: float,
+) -> float:
+    """Compute intrinsic value using a simple DCF model.
+
+    Parameters are expressed as percentages except for `years` and `fcf`.
+    For example ``growth_rate=5`` means 5%.
+    """
+    if years <= 0:
+        raise ValueError("years must be > 0")
+
+    growth = growth_rate / 100 if growth_rate > 1 else growth_rate
+    discount = discount_rate / 100 if discount_rate > 1 else discount_rate
+    terminal = terminal_growth / 100 if terminal_growth > 1 else terminal_growth
+
+    pv = 0.0
+    for t in range(1, years + 1):
+        future_fcf = fcf * (1 + growth) ** t
+        pv += future_fcf / (1 + discount) ** t
+
+    terminal_value = (
+        fcf * (1 + growth) ** years * (1 + terminal) / (discount - terminal)
+    )
+    pv += terminal_value / (1 + discount) ** years
+    return pv
+
+
+def fetch_price(ticker: str) -> Optional[float]:
+    """Fetch the current market price for ``ticker`` from Yahoo Finance."""
+    url = (
+        "https://query1.finance.yahoo.com/v7/finance/quote?symbols=" + ticker.upper()
+    )
+    try:
+        with urllib.request.urlopen(url) as resp:
+            data = json.load(resp)
+    except Exception:
+        return None
+    results = data.get("quoteResponse", {}).get("result", [])
+    if not results:
+        return None
+    price = results[0].get("regularMarketPrice")
+    return float(price) if price is not None else None

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,94 @@
+"""Simple Flask web app for computing discounted cash flow values."""
+
+from __future__ import annotations
+
+from flask import Flask, render_template_string, request
+
+from stock_analysis.dcf import compute_intrinsic_value, fetch_price
+
+app = Flask(__name__)
+
+FORM_HTML = """
+<!doctype html>
+<title>DCF Calculator</title>
+<h1>Discounted Cash Flow Calculator</h1>
+<form method="post">
+  <label>Free Cash Flow:
+    <input type="number" step="0.01" name="fcf" value="{{ request.form.get('fcf','') }}" required>
+  </label><br>
+  <label>Growth Rate (%):
+    <input type="number" step="0.01" name="growth_rate" value="{{ request.form.get('growth_rate','') }}" required>
+  </label><br>
+  <label>Discount Rate (%):
+    <input type="number" step="0.01" name="discount_rate" value="{{ request.form.get('discount_rate','') }}" required>
+  </label><br>
+  <label>Projection Years:
+    <input type="number" name="years" value="{{ request.form.get('years',5) }}" required>
+  </label><br>
+  <label>Terminal Growth (%):
+    <input type="number" step="0.01" name="terminal_growth" value="{{ request.form.get('terminal_growth',2) }}" required>
+  </label><br>
+  <label>Ticker (optional):
+    <input type="text" name="ticker" value="{{ request.form.get('ticker','') }}">
+  </label><br>
+  <label>Shares (optional):
+    <input type="number" step="0.01" name="shares" value="{{ request.form.get('shares','') }}">
+  </label><br>
+  <input type="submit" value="Calculate">
+</form>
+{% if intrinsic_value is not none %}
+<h2>Results</h2>
+<p>Total intrinsic value: {{ intrinsic_value | round(2) }}</p>
+{% if shares %}
+<p>Intrinsic value per share: {{ intrinsic_value_per_share | round(2) }}</p>
+{% endif %}
+{% if price is not none %}
+<p>Market price per share: {{ price }}</p>
+{% if intrinsic_value_per_share is not none %}
+<p>Difference: {{ (intrinsic_value_per_share - price) | round(2) }}</p>
+{% endif %}
+{% endif %}
+{% endif %}
+"""
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    intrinsic_value = None
+    intrinsic_value_per_share = None
+    price = None
+    shares = None
+    if request.method == "POST":
+        try:
+            fcf = float(request.form["fcf"])
+            growth_rate = float(request.form["growth_rate"])
+            discount_rate = float(request.form["discount_rate"])
+            years = int(request.form["years"])
+            terminal_growth = float(request.form["terminal_growth"])
+            ticker = request.form.get("ticker", "").strip()
+            shares_input = request.form.get("shares", "").strip()
+
+            intrinsic_value = compute_intrinsic_value(
+                fcf, growth_rate, discount_rate, years, terminal_growth
+            )
+
+            if shares_input:
+                shares = float(shares_input)
+                if shares:
+                    intrinsic_value_per_share = intrinsic_value / shares
+
+            if ticker:
+                price = fetch_price(ticker)
+        except ValueError:
+            intrinsic_value = None
+    return render_template_string(
+        FORM_HTML,
+        intrinsic_value=intrinsic_value,
+        intrinsic_value_per_share=intrinsic_value_per_share,
+        price=price,
+        shares=shares,
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- implement simple DCF computation and price fetcher
- create a small Flask app to gather inputs and show results
- document how to run the web app

## Testing
- `python -m py_compile stock_analysis/dcf.py webapp.py`

------
https://chatgpt.com/codex/tasks/task_e_6864b32cb15c83338576845a4a0633eb