### PR TITLE
Add intrinsic value calculation and tests

### DIFF
--- a/stock_analysis/__init__.py
+++ b/stock_analysis/__init__.py
@@ -1,0 +1,6 @@
+"""Utility functions for stock analysis."""
+
+from .analysis import read_prices, moving_average, main
+from .valuation import compute_intrinsic_value
+
+__all__ = ["read_prices", "moving_average", "main", "compute_intrinsic_value"]

--- a/stock_analysis/valuation.py
+++ b/stock_analysis/valuation.py
@@ -1,0 +1,26 @@
+"""Valuation utilities for stock analysis."""
+
+from typing import List
+
+
+def compute_intrinsic_value(
+    cash_flows: List[float],
+    discount_rate: float,
+    terminal_growth_rate: float = 0.0,
+) -> float:
+    """Compute the present value of future cash flows using a DCF model."""
+    if discount_rate <= terminal_growth_rate:
+        raise ValueError("discount_rate must be greater than terminal_growth_rate")
+
+    value = 0.0
+    for t, cf in enumerate(cash_flows, start=1):
+        value += cf / (1 + discount_rate) ** t
+
+    if cash_flows:
+        last_cf = cash_flows[-1]
+        terminal_value = last_cf * (1 + terminal_growth_rate) / (
+            discount_rate - terminal_growth_rate
+        )
+        value += terminal_value / (1 + discount_rate) ** len(cash_flows)
+
+    return value

--- a/tests/test_valuation.py
+++ b/tests/test_valuation.py
@@ -1,0 +1,16 @@
+import math
+from stock_analysis.valuation import compute_intrinsic_value
+
+
+def test_intrinsic_value_no_growth():
+    cash_flows = [100, 110, 121]
+    discount_rate = 0.1
+    # PV = 100/1.1 + 110/1.1^2 + 121/1.1^3 + terminal using last CF with zero growth
+    expected = (
+        cash_flows[0] / 1.1
+        + cash_flows[1] / 1.1**2
+        + cash_flows[2] / 1.1**3
+        + cash_flows[2] / 0.1 / 1.1**3
+    )
+    result = compute_intrinsic_value(cash_flows, discount_rate, terminal_growth_rate=0.0)
+    assert math.isclose(result, expected, rel_tol=1e-9)


### PR DESCRIPTION
## Summary
- add a valuation module with `compute_intrinsic_value`
- expose the new function in `stock_analysis.__init__`
- add pytest-based test verifying intrinsic value without terminal growth

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b33d94388333bcb8747fba4a7b30